### PR TITLE
add a PR and Issue template to warn contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+This is a work in progress repository, the files contained in this repository are only the code file (.m files) contained in GSW(Matlab).
+It is intended to be a method of assisting those who are translating the code into their preferred language.
+
+Do not download this code and treat it as an distributed release of the GSW code - it is not under any circumstance.
+
+The ONLY location to download software is from the TEOS-10 website http://www.TEOS-10.org/
+
+There is no guarantee that PRs and issues here will be addressed by the authors of the Matlab version of GSW.

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+This is a work in progress repository, the files contained in this repository are only the code file (.m files) contained in GSW(Matlab).
+It is intended to be a method of assisting those who are translating the code into their preferred language.
+
+Do not download this code and treat it as an distributed release of the GSW code - it is not under any circumstance.
+
+The ONLY location to download software is from the TEOS-10 website http://www.TEOS-10.org/
+
+There is no guarantee that PRs and issues here will be addressed by the authors of the Matlab version of GSW.


### PR DESCRIPTION
@efiring we got a few PRs and issues to the Matlab version of the code that are growing stale and folks are probably frustrated with it. However, the goal of this repository was never to be a central place for the Matlab development of the GSW library. These templates should help explain that to folks who skips the README.

What do you think?